### PR TITLE
Fix unused import in router

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,7 +18,7 @@ export const router = createRouter({
       props: true
     }
   ],
-  scrollBehavior(to, from, savedPosition) {
+  scrollBehavior(to, _from, savedPosition) {
     if (savedPosition) {
       return savedPosition
     }


### PR DESCRIPTION
Rename unused `from` parameter to `_from` in `scrollBehavior` to fix TypeScript error TS6133 and enable successful production build.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a392ac5-33ab-4331-8b2d-d7a3c9139db5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a392ac5-33ab-4331-8b2d-d7a3c9139db5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

